### PR TITLE
Using document store instead of node one

### DIFF
--- a/application/backend/pom.xml
+++ b/application/backend/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>pl.ds.luna</groupId>
     <artifactId>luna-application</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>luna-backend</artifactId>

--- a/application/backend/pom.xml
+++ b/application/backend/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>pl.ds.luna</groupId>
     <artifactId>luna-application</artifactId>
-    <version>1.2.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>luna-backend</artifactId>

--- a/application/pom.xml
+++ b/application/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>pl.ds.luna</groupId>
     <artifactId>luna-parent</artifactId>
-    <version>1.2.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/application/pom.xml
+++ b/application/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>pl.ds.luna</groupId>
     <artifactId>luna-parent</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/content/pom.xml
+++ b/content/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>pl.ds.luna</groupId>
     <artifactId>luna-parent</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>luna-content</artifactId>

--- a/content/pom.xml
+++ b/content/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>pl.ds.luna</groupId>
     <artifactId>luna-parent</artifactId>
-    <version>1.2.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>luna-content</artifactId>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -52,7 +52,7 @@
       <groupId>pl.ds.websight</groupId>
       <artifactId>websight-cms-ce-feature</artifactId>
       <version>${websight.cms.version}</version>
-      <classifier>oak-node-store</classifier>
+      <classifier>oak-document-store</classifier>
       <type>slingosgifeature</type>
     </dependency>
   </dependencies>
@@ -99,7 +99,7 @@
                 <groupId>pl.ds.websight</groupId>
                 <artifactId>websight-cms-ce-feature</artifactId>
                 <version>${websight.cms.version}</version>
-                <classifier>oak-node-store</classifier>
+                <classifier>oak-document-store</classifier>
                 <type>slingosgifeature</type>
               </includeArtifact>
             </aggregate>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>pl.ds.luna</groupId>
     <artifactId>luna-parent</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>luna-distribution</artifactId>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -28,14 +28,6 @@
   <name>Luna: Distribution</name>
   <description>Luna distribution that builds the Docker Image for the projects running on WebSight.</description>
 
-  <properties>
-    <!-- IT tests properties -->
-    <it.extra.bundles.count>83</it.extra.bundles.count>
-    <it.startTimeoutSeconds>30</it.startTimeoutSeconds>
-
-    <websight.base.version>1.2.15</websight.base.version>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>pl.ds.luna</groupId>
@@ -62,31 +54,6 @@
       <version>${websight.cms.version}</version>
       <classifier>oak-document-store</classifier>
       <type>slingosgifeature</type>
-    </dependency>
-    <dependency>
-      <groupId>pl.ds.websight</groupId>
-      <artifactId>websight-base-sling-feature</artifactId>
-      <version>${websight.base.version}</version>
-      <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.rest-assured</groupId>
-      <artifactId>rest-assured</artifactId>
-      <version>5.1.1</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.awaitility</groupId>
-      <artifactId>awaitility</artifactId>
-      <version>4.2.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-      <version>1.7.36</version>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 
@@ -142,6 +109,12 @@
               <includeClassifier>websight-cms-luna</includeClassifier>
             </scan>
           </scans>
+          <repositories>
+            <repository>
+              <includeClassifier>websight-cms-luna</includeClassifier>
+              <includeClassifier>docker</includeClassifier>
+            </repository>
+          </repositories>
           <outputDir>target</outputDir>
         </configuration>
         <executions>
@@ -178,96 +151,6 @@
               <!-- 1.1.28 and newer versions don't work out-of-the-box due to SLING-10956 -->
               <artifact>org.apache.sling:org.apache.sling.feature.launcher:1.1.26</artifact>
               <stripVersion>true</stripVersion>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <version>3.3.0</version>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>pre-integration-test</phase>
-            <configuration>
-              <portNames>
-                <portName>cms.port</portName>
-                <portName>mongo.port</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.sling</groupId>
-        <artifactId>feature-launcher-maven-plugin</artifactId>
-        <version>0.1.2</version>
-        <configuration>
-          <launches>
-            <launch>
-              <id>websight-cms-luna</id>
-              <feature>
-                <groupId>${project.groupId}</groupId>
-                <artifactId>${project.artifactId}</artifactId>
-                <version>${project.version}</version>
-                <classifier>websight-cms-luna</classifier>
-                <type>slingosgifeature</type>
-              </feature>
-              <launcherArguments>
-                <frameworkProperties>
-                  <org.osgi.service.http.port>${cms.port}</org.osgi.service.http.port>
-                </frameworkProperties>
-              </launcherArguments>
-              <environmentVariables>
-                <MONGODB_PORT>${mongo.port}</MONGODB_PORT>
-                <WS_ADMIN_USERNAME>${websight.admin.username}</WS_ADMIN_USERNAME>
-                <WS_ADMIN_PASSWORD>${websight.admin.password}</WS_ADMIN_PASSWORD>
-              </environmentVariables>
-              <startTimeoutSeconds>${it.startTimeoutSeconds}</startTimeoutSeconds>
-            </launch>
-          </launches>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>start</goal>
-              <goal>stop</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-failsafe-plugin</artifactId>
-        <version>3.0.0-M7</version>
-        <configuration>
-          <dependenciesToScan>
-            <dependency>pl.ds.websight:websight-base-sling-feature</dependency>
-          </dependenciesToScan>
-          <systemPropertyVariables>
-            <WS_ADMIN_USERNAME>${websight.admin.username}</WS_ADMIN_USERNAME>
-            <WS_ADMIN_PASSWORD>${websight.admin.password}</WS_ADMIN_PASSWORD>
-            <WS_APPLICATION_VERSION>${project.version}</WS_APPLICATION_VERSION>
-          </systemPropertyVariables>
-          <argLine>--add-opens java.base/java.lang=org.apache.sling.commons.threads</argLine>
-          <argLine>--add-opens java.base/java.lang=ALL-UNNAMED</argLine>
-        </configuration>
-        <executions>
-          <execution>
-            <id>cms-integration-tests</id>
-            <goals>
-              <goal>integration-test</goal>
-              <goal>verify</goal>
-            </goals>
-            <configuration>
-              <systemPropertyVariables>
-                <WS_HTTP_PORT>${cms.port}</WS_HTTP_PORT>
-                <FEATURE_EXTRA_ACTIVE_BUNDLES_COUNT>${it.extra.bundles.count}</FEATURE_EXTRA_ACTIVE_BUNDLES_COUNT>
-              </systemPropertyVariables>
             </configuration>
           </execution>
         </executions>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>pl.ds.luna</groupId>
     <artifactId>luna-parent</artifactId>
-    <version>1.2.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>luna-distribution</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>pl.ds.luna</groupId>
   <artifactId>luna-parent</artifactId>
-  <version>1.1.1-SNAPSHOT</version>
+  <version>1.2.0-SNAPSHOT</version>
   <name>Luna Project Parent</name>
   <packaging>pom</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>pl.ds.luna</groupId>
   <artifactId>luna-parent</artifactId>
-  <version>1.2.0-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
   <name>Luna Project Parent</name>
   <packaging>pom</packaging>
 

--- a/tests/content/pom.xml
+++ b/tests/content/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>pl.ds.luna</groupId>
     <artifactId>luna-tests</artifactId>
-    <version>1.2.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/tests/content/pom.xml
+++ b/tests/content/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>pl.ds.luna</groupId>
     <artifactId>luna-tests</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/tests/end-to-end/pom.xml
+++ b/tests/end-to-end/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>pl.ds.luna</groupId>
     <artifactId>luna-tests</artifactId>
-    <version>1.2.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/tests/end-to-end/pom.xml
+++ b/tests/end-to-end/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>pl.ds.luna</groupId>
     <artifactId>luna-tests</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>pl.ds.luna</groupId>
     <artifactId>luna-parent</artifactId>
-    <version>1.2.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>pl.ds.luna</groupId>
     <artifactId>luna-parent</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
Replacing node store with a document one

## Description
Instead of using a node store, we should use a document one.

## Motivation and Context
We should not use node store because we will lose our data if we update a starter version

## Screenshots (if appropriate)

## Upgrade notes (if appropriate)
The user should prepare a package with all the content he has in the current version. Use a package manager from admin tools to do so. This content package should be imported after updating the starter to a newer version. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) labeled with `bug`
- [ ] New feature (non-breaking change which adds functionality) labeled with `enhancement`
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code standards](../CONTRIBUTING.md) of this project.
- [ ] My change requires updating the documentation. I have updated the documentation accordingly.
