### PR TITLE
Expose ports 81/82 for codespace integration

### DIFF
--- a/distribution/src/main/docker/nginx/bulma.conf
+++ b/distribution/src/main/docker/nginx/bulma.conf
@@ -14,6 +14,7 @@
 
 server {
     listen       80;
+    listen       82 default_server;
     server_name  bulma.127.0.0.1.nip.io;
     index        Personal.html;
 

--- a/distribution/src/main/docker/nginx/luna.conf
+++ b/distribution/src/main/docker/nginx/luna.conf
@@ -14,6 +14,7 @@
 
 server {
     listen       80;
+    listen       81 default_server;
     server_name  luna.127.0.0.1.nip.io;
     index        Homepage.html;
 

--- a/environment/local/docker-compose.yml
+++ b/environment/local/docker-compose.yml
@@ -66,6 +66,8 @@ services:
     image: ds/nginx-luna:latest
     ports:
       - "80:80"
+      - "81:81"
+      - "82:82"
     volumes:
       - luna-project_site_repository:/usr/share/nginx/html:ro
 


### PR DESCRIPTION
## Description
Expose ports 81 and 82 and set them as default ports on Nginx Bulma/Howlite

## Motivation and Context
GitHub Codespace generates a unique domain for each setup. Each server has to act as a default one on different port, to enable Codespace access to Nginx.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue) labeled with `bug`
- [x] New feature (non-breaking change which adds functionality) labeled with `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the [code standards](/CONTRIBUTING.md) of this project.
- [ ] My change requires updating the documentation. I have updated the documentation accordingly.
