### PR TITLE
Fix flaky test - increase default timeout

### DIFF
--- a/tests/end-to-end/cypress.config.ts
+++ b/tests/end-to-end/cypress.config.ts
@@ -29,6 +29,6 @@ export default defineConfig({
     baseUrl: 'http://localhost:8080',
     specPattern: 'tests/**/*.cy.{js,jsx,ts,tsx}',
     supportFile: 'support/index.ts',
-    defaultCommandTimeout: 10000
+    defaultCommandTimeout: 30000
   }
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We had one flaky test failing randomly on timeout

## Motivation and Context

- Stabilize e2e tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) labeled with `bug`
- [ ] New feature (non-breaking change which adds functionality) labeled with `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code standards](/CONTRIBUTING.md) of this project.
- [ ] My change requires updating the documentation. I have updated the documentation accordingly.
