### PR TITLE
Use OCID provider for GH Actions GCP authentication

### DIFF
--- a/.github/DOCS.md
+++ b/.github/DOCS.md
@@ -1,0 +1,21 @@
+# Workflow Documentation
+
+## Environment Variables
+The following environment variables are required to run this project:
+- `GCP_DEV_PROJECT_ID` - GCP project ID for development
+- `GCP_DEV_SERVICE_ACCOUNT_EMAIL` - GCP service account email for development
+- `GCP_DEV_IMAGE_REGISTRY_URI` - GCP image registry uri for development (region specific)
+- `GCP_DEV_WORKLOAD_IDENTITY_PROVIDER` - GCP workload identity provider for development
+- `GCP_DEFAULT_REGION` - GCP default region
+
+## GCP Workload Identity Provider
+We use GH Action to authenticate with GCP. To do so, we need to create a GCP service account and assign it the following roles:
+- `Artifact Registry Writer` - to push Docker images to GCP Artifact Registry
+- `Cloud Run Admin` - to deploy Docker images to GCP Cloud Run
+- `Service Account User` - to run Cloud Run service as a service account
+- `Service Accout OpenID Connect Token Creator` - to authenticate with GCP using service account
+
+The service account is used in Workload Identity Provider to authenticate with GCP configured in `google-github-actions/auth@v1`. Read more details [here](https://github.com/google-github-actions/auth#setting-up-workload-identity-federation).
+
+## GCP Artifact Registry
+We use GCP Artifact Registry to store Docker images. To do so, create a GCP Artifact Registry repository with `cms-starter` name and `docker` format. Read more details [here](https://cloud.google.com/artifact-registry/docs/docker/quickstart). The full registry name is combined from `${{ vars.GCP_DEV_IMAGE_REGISTRY_URI }}/${{ vars.GCP_DEV_PROJECT_ID }}/cms-starter`. To reduce storage costs, remember to configure the repository cleanup policy (e.g., 3 days).

--- a/.github/workflows/ephemeral-env-cleanup.yml
+++ b/.github/workflows/ephemeral-env-cleanup.yml
@@ -14,6 +14,9 @@
 
 name: Ephemeral environment - cleanup
 
+permissions:
+  id-token: write
+
 on:
   workflow_dispatch:
   schedule:
@@ -31,13 +34,13 @@ jobs:
         uses: google-github-actions/auth@v1
         with:
           token_format: access_token
-          credentials_json: ${{ secrets.GCP_SERVICE_CREDENTIALS_JSON }}
-          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_SERVICE_ACCOUNT_EMAIL }}
       - name: Destroy Cloud Run service
         run: |
           environments=$(gcloud run services list --format json | jq '.[] | .metadata.name' -r)
           for env in $environments; do
             if [[ $env == websight-cms-* ]]; then
-              gcloud run services delete -q $env --region=europe-west1
+              gcloud run services delete -q $env --region=${{ vars.GCP_DEFAULT_REGION }}
             fi
           done

--- a/.github/workflows/ephemeral-env-cleanup.yml
+++ b/.github/workflows/ephemeral-env-cleanup.yml
@@ -34,8 +34,8 @@ jobs:
         uses: google-github-actions/auth@v1
         with:
           token_format: access_token
-          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ vars.GCP_SERVICE_ACCOUNT_EMAIL }}
+          workload_identity_provider: ${{ vars.GCP_DEV_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_DEV_SERVICE_ACCOUNT_EMAIL }}
       - name: Destroy Cloud Run service
         run: |
           environments=$(gcloud run services list --format json | jq '.[] | .metadata.name' -r)

--- a/.github/workflows/ephemeral-env-create.yml
+++ b/.github/workflows/ephemeral-env-create.yml
@@ -14,6 +14,9 @@
 
 name: Ephemeral environment - create
 
+permissions:
+  id-token: write
+
 on:
   workflow_dispatch:
 
@@ -49,8 +52,8 @@ jobs:
         uses: google-github-actions/auth@v1
         with:
           token_format: access_token
-          credentials_json: ${{ secrets.GCP_SERVICE_CREDENTIALS_JSON }}
-          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_SERVICE_ACCOUNT_EMAIL }}
       - name: Login to GAR
         uses: docker/login-action@v3
         with:
@@ -66,11 +69,11 @@ jobs:
           export IMAGE_REGISTRY="europe-west1-docker.pkg.dev/websight-dxp-development/cms-starter"
           export ENV_NAME_POSTFIX=$(echo ${{ github.ref_name }} | sed 's/[^a-zA-Z0-9]/-/g' | cut -c 1-40)
           export IMAGE_TAG=${{ github.sha }}
-          envsubst < environment/remote-gcp-cloudrun/service.tmpl.yaml | gcloud run services replace --region=europe-west1 -
+          envsubst < environment/remote-gcp-cloudrun/service.tmpl.yaml | gcloud run services replace --region=${{ vars.GCP_DEFAULT_REGION }} -
           gcloud run services add-iam-policy-binding websight-cms-$ENV_NAME_POSTFIX \
             --member="allUsers" \
             --role="roles/run.invoker" \
-            --region=europe-west1
+            --region=${{ vars.GCP_DEFAULT_REGION }}
 
       - name: Clear snapshots before caching
         if: always()

--- a/.github/workflows/ephemeral-env-create.yml
+++ b/.github/workflows/ephemeral-env-create.yml
@@ -52,21 +52,21 @@ jobs:
         uses: google-github-actions/auth@v1
         with:
           token_format: access_token
-          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ vars.GCP_SERVICE_ACCOUNT_EMAIL }}
+          workload_identity_provider: ${{ vars.GCP_DEV_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_DEV_SERVICE_ACCOUNT_EMAIL }}
       - name: Login to GAR
         uses: docker/login-action@v3
         with:
-          registry: europe-west1-docker.pkg.dev
+          registry: ${{ vars.GCP_DEV_IMAGE_REGISTRY_URI }}
           username: oauth2accesstoken
           password: ${{ steps.auth.outputs.access_token }}
 
       - name: Build image and push to registry
-        run: ./mvnw --batch-mode install -DskipITs -Ddocker.cms-project.name=europe-west1-docker.pkg.dev/websight-dxp-development/cms-starter/websight-cms-starter -Ddocker.cms-project.tag=${{ github.sha }} -P release-cms-image
+        run: ./mvnw --batch-mode install -DskipITs -Ddocker.cms-project.name=${{ vars.GCP_DEV_IMAGE_REGISTRY_URI }}/${{ vars.GCP_DEV_PROJECT_ID }}/cms-starter/websight-cms-starter -Ddocker.cms-project.tag=${{ github.sha }} -P release-cms-image
 
       - name: Deploy new Cloud Run service
         run: |
-          export IMAGE_REGISTRY="europe-west1-docker.pkg.dev/websight-dxp-development/cms-starter"
+          export IMAGE_REGISTRY="${{ vars.GCP_DEV_IMAGE_REGISTRY_URI }}/${{ vars.GCP_DEV_PROJECT_ID }}/cms-starter"
           export ENV_NAME_POSTFIX=$(echo ${{ github.ref_name }} | sed 's/[^a-zA-Z0-9]/-/g' | cut -c 1-40)
           export IMAGE_TAG=${{ github.sha }}
           envsubst < environment/remote-gcp-cloudrun/service.tmpl.yaml | gcloud run services replace --region=${{ vars.GCP_DEFAULT_REGION }} -

--- a/.github/workflows/ephemeral-env-destroy.yml
+++ b/.github/workflows/ephemeral-env-destroy.yml
@@ -32,8 +32,8 @@ jobs:
         uses: google-github-actions/auth@v1
         with:
           token_format: access_token
-          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ vars.GCP_SERVICE_ACCOUNT_EMAIL }}
+          workload_identity_provider: ${{ vars.GCP_DEV_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_DEV_SERVICE_ACCOUNT_EMAIL }}
       - name: Destroy Cloud Run service
         run: |
           export ENV_NAME_POSTFIX=$(echo ${{ github.ref_name }} | sed 's/[^a-zA-Z0-9]/-/g' | cut -c 1-40)

--- a/.github/workflows/ephemeral-env-destroy.yml
+++ b/.github/workflows/ephemeral-env-destroy.yml
@@ -14,9 +14,11 @@
 
 name: Ephemeral environment - destroy
 
+permissions:
+  id-token: write
+
 on:
   workflow_dispatch:
-
 
 jobs:
   destroy-ephemeral-env:
@@ -30,9 +32,9 @@ jobs:
         uses: google-github-actions/auth@v1
         with:
           token_format: access_token
-          credentials_json: ${{ secrets.GCP_SERVICE_CREDENTIALS_JSON }}
-          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_SERVICE_ACCOUNT_EMAIL }}
       - name: Destroy Cloud Run service
         run: |
           export ENV_NAME_POSTFIX=$(echo ${{ github.ref_name }} | sed 's/[^a-zA-Z0-9]/-/g' | cut -c 1-40)
-          gcloud run services delete -q websight-cms-$ENV_NAME_POSTFIX --region=europe-west1
+          gcloud run services delete -q websight-cms-$ENV_NAME_POSTFIX --region=${{ vars.GCP_DEFAULT_REGION }}


### PR DESCRIPTION
Secure GCP authentication with OAuth strategy.

## Description
We stored JSON token with service user credentials before. We use OAuth approach now. More details here: https://github.com/google-github-actions/auth#setting-up-workload-identity-federation

## Motivation and Context
Security concerns.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) labeled with `bug`
- [x] New feature (non-breaking change which adds functionality) labeled with `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code standards](/CONTRIBUTING.md) of this project.
- [ ] My change requires updating the documentation. I have updated the documentation accordingly.
