### PR TITLE
Add capability to release starter image to GAR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           java-version: '17'
           distribution: 'adopt'
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -45,6 +46,21 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v1
         with:
           registry-type: public
+      
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v1
+        with:
+          token_format: access_token
+          workload_identity_provider: ${{ vars.GCP_RELEASE_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_RELEASE_SERVICE_ACCOUNT_EMAIL }}
+      - name: Login to GAR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ vars.GCP_RELEASE_IMAGE_REGISTRY_URI }}
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
+
       - name: Configure Git and Maven settings
         run: |
           git config --global user.email "github.actions@ds.pl"
@@ -64,5 +80,6 @@ jobs:
             git fetch --tags
             CURRENT_VERSION=$(git tag | sort -V | tail -1)
             git checkout tags/${CURRENT_VERSION}
-      - name: Validate & publish Luna artifacts
-        run: ./mvnw --batch-mode deploy -P ecr,release-cms-image,release-nginx-image,-default
+
+      - name: Validate & publish starter artifacts
+        run: ./mvnw --batch-mode deploy -P release-cms-image,release-nginx-image,-default

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -342,7 +342,8 @@
     <profile>
       <id>release-cms-image</id>
       <properties>
-        <!-- <docker.skip.push>false</docker.skip.push> -->
+        <docker.skip.push>false</docker.skip.push>
+        <docker.cms-project.tag>${project.version}</docker.cms-project.tag>
       </properties>
       <build>
         <plugins>
@@ -404,6 +405,7 @@
       <id>release-nginx-image</id>
       <properties>
         <docker.skip.push>false</docker.skip.push>
+        <docker.nginx.tag>${project.version}</docker.nginx.tag>
       </properties>
       <build>
         <plugins>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -318,14 +318,14 @@
                 <configuration>
                   <images>
                     <image>
-                      <name>${docker.cms-project.name}:${docker.cms-project.tag}</name>
+                      <name>${docker.cms-project.name}</name>
                       <build>
                         <dockerFile>src/main/docker/websight-cms-starter/Dockerfile</dockerFile>
                         <contextDir>${project.basedir}</contextDir>
                       </build>
                     </image>
                     <image>
-                      <name>${docker.nginx.name}:${docker.nginx.tag}</name>
+                      <name>${docker.nginx.name}</name>
                       <build>
                         <dockerFile>src/main/docker/nginx/Dockerfile</dockerFile>
                         <contextDir>${project.basedir}</contextDir>
@@ -340,27 +340,9 @@
       </build>
     </profile>
     <profile>
-      <id>ecr</id>
-      <properties>
-        <docker.cms-project.name>public.ecr.aws/ds/websight-cms-starter</docker.cms-project.name>
-        <docker.cms-project.tag>${project.version}</docker.cms-project.tag>
-        <docker.nginx.name>public.ecr.aws/ds/websight-nginx-starter</docker.nginx.name>
-        <docker.nginx.tag>${project.version}</docker.nginx.tag>
-      </properties>
-    </profile>
-    <profile>
-      <id>dockerhub</id>
-      <properties>
-        <docker.cms-project.name>${docker.hub.username}/websight-cms-starter</docker.cms-project.name>
-        <docker.cms-project.tag>${project.version}</docker.cms-project.tag>
-        <docker.nginx.name>${docker.hub.username}/websight-nginx-starter</docker.nginx.name>
-        <docker.nginx.tag>${project.version}</docker.nginx.tag>
-      </properties>
-    </profile>
-    <profile>
       <id>release-cms-image</id>
       <properties>
-        <docker.skip.push>false</docker.skip.push>
+        <!-- <docker.skip.push>false</docker.skip.push> -->
       </properties>
       <build>
         <plugins>
@@ -371,7 +353,20 @@
               <removeVolumes>true</removeVolumes>
               <images>
                 <image>
-                  <name>${docker.cms-project.name}:${docker.cms-project.tag}</name>
+                  <name>public.ecr.aws/ds/websight-cms-starter:${docker.cms-project.tag}</name>
+                  <build>
+                    <buildx>
+                      <platforms>
+                        <platform>linux/amd64</platform>
+                        <platform>linux/arm64</platform>
+                      </platforms>
+                    </buildx>
+                    <dockerFile>src/main/docker/websight-cms-starter/Dockerfile</dockerFile>
+                    <contextDir>${project.basedir}</contextDir>
+                  </build>
+                </image>
+                <image>
+                  <name>europe-docker.pkg.dev/websight-io/public/websight-cms-starter:${docker.cms-project.tag}</name>
                   <build>
                     <buildx>
                       <platforms>

--- a/environment/remote-gcp-cloudrun/README.md
+++ b/environment/remote-gcp-cloudrun/README.md
@@ -10,27 +10,6 @@ Cloud Run is a serverless platform that allows you to run `stateless` HTTP conta
 
 Make sure you have:
 - your [GCP environment set](https://cloud.google.com/run/docs/setup)
-- [DockerHub](https://hub.docker.com/) account to store CMS Docker image publicly
-
-## Build and Push image to DockerHub
-
-Authenticate to DockerHub:
-```bash
-docker login
-```
-
-Set environment variables:
-```bash
-export DOCKERHUB_USERNAME=<your dockerhub username>
-export IMAGE_REGISTRY=${DOCKERHUB_USERNAME}
-export ENV_NAME_POSTFIX=${DOCKERHUB_USERNAME}
-export IMAGE_TAG=latest
-```
-
-Build and push CSM Docker image with a single command:
-```bash
-../../mvnw clean install -f ../../pom.xml -P dockerhub,release-cms-image -Ddocker.hub.username=$DOCKERHUB_USERNAME
-```
 
 ## Customize CMS admin password
 
@@ -48,6 +27,14 @@ gcloud iam service-accounts list --format json | jq -r '.[] | select(.displayNam
 ```
 
 ## Run environment
+
+Set environment variables:
+```bash
+export IMAGE_REGISTRY=europe-docker.pkg.dev/websight-io/public
+export ENV_NAME_POSTFIX=<your-name>
+export IMAGE_TAG=<released-version>
+```
+
 Run the service with command
 ```bash
 envsubst < service.tmpl.yaml | gcloud run services replace --region=europe-west1 -
@@ -56,7 +43,7 @@ and then open the URL printed in the console (it will be not available publicly 
 
 To make your environment publicly available, run the following command:
 ```bash
-gcloud run services add-iam-policy-binding websight-cms-$DOCKERHUB_USERNAME \
+gcloud run services add-iam-policy-binding websight-cms-$ENV_NAME_POSTFIX \
     --member="allUsers" \
     --role="roles/run.invoker" \
     --region=europe-west1
@@ -68,7 +55,7 @@ and login with username `wsadmin` and password from `.secrets/admin-password` fi
 
 To delete the environment and the secret, run the following commands:
 ```bash
-gcloud run services delete websight-cms-$DOCKERHUB_USERNAME --region=europe-west1
+gcloud run services delete websight-cms-$ENV_NAME_POSTFIX --region=europe-west1
 gcloud secrets delete websight-admin-password
 ```
 


### PR DESCRIPTION
## Description
Google CloudRun requires public images either from Docker Hub or Google Artifact Registry (GAR).
For a short transition period we want to keep both, ECR and GAR to keep released images, so that we have working CloudRun setup while there will be time to update the documentation.

## Motivation and Context
- Simplify running single-container instances in Cloud Run using the starter public images
- Keep backward compatibility with the current documentation (that still uses ECR)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) labeled with `bug`
- [x] New feature (non-breaking change which adds functionality) labeled with `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code standards](/CONTRIBUTING.md) of this project.
- [x] My change requires updating the documentation. I have updated the documentation accordingly.
