### PR TITLE
Set proper Cloud Run environment name in CI

### DIFF
--- a/.github/scripts/get-cloud-run-env-name.sh
+++ b/.github/scripts/get-cloud-run-env-name.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Copyright (C) 2022 Dynamic Solutions
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# fail fast
+set -e
+
+BRANCH_NAME=${1}
+
+# Cloud Run environment must be compatible with RFC 1123 Label Names https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names
+# It should cosists of only lowercase, digits, and hyphens; must begin with letter, and may not end with hyphen; must be less than 64 characters.
+ENV_NAME=$(echo websight-cms-${BRANCH_NAME} | sed 's/[^a-zA-Z0-9]/-/g' | cut -c 1-63)
+ENV_NAME=$(echo ${ENV_NAME} | tr '[:upper:]' '[:lower:]')
+
+if [[ "$ENV_NAME" == *- ]]
+then
+  ENV_NAME=$(echo ${ENV_NAME} | cut -c 1-62)
+  echo "${ENV_NAME}0"
+else
+  echo "${ENV_NAME}"
+fi

--- a/.github/workflows/env-ephemeral-create.yml
+++ b/.github/workflows/env-ephemeral-create.yml
@@ -46,8 +46,8 @@ jobs:
           
       - name: Deploy new Cloud Run environment
         run: |
-          export ENV_NAME_POSTFIX=$(echo ${{ github.ref_name }} | sed 's/[^a-zA-Z0-9]/-/g' | cut -c 1-40)
-          gcloud run deploy websight-cms-$ENV_NAME_POSTFIX --source=. \
+          CLOUD_RUN_ENV_NAME=$(./.github/scripts/get-cloud-run-env-name.sh ${{ github.ref_name }})
+          gcloud run deploy $CLOUD_RUN_ENV_NAME --source=. \
           --update-secrets=/run/secrets/admin.password=websight-admin-password:1 \
           --cpu=2 --memory=2Gi --no-cpu-throttling \
           --min-instances=1 --max-instances=1 \

--- a/.github/workflows/env-ephemeral-destroy.yml
+++ b/.github/workflows/env-ephemeral-destroy.yml
@@ -38,5 +38,5 @@ jobs:
           
       - name: Destroy Cloud Run service
         run: |
-          export ENV_NAME_POSTFIX=$(echo ${{ github.ref_name }} | sed 's/[^a-zA-Z0-9]/-/g' | cut -c 1-40)
-          gcloud run services delete -q websight-cms-$ENV_NAME_POSTFIX --region=${{ vars.GCP_DEFAULT_REGION }}
+          CLOUD_RUN_ENV_NAME=$(./.github/scripts/get-cloud-run-env-name.sh ${{ github.ref_name }})
+          gcloud run services delete -q $CLOUD_RUN_ENV_NAME --region=${{ vars.GCP_DEFAULT_REGION }}


### PR DESCRIPTION
## Description
Make CloudRun environment name compatible with Kubernetes RFC 1123 Lebel Names

## Motivation and Context
According to Cloud Run docs, the service name must be [Kubernetes RFC 1123 Lebel Names](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names) compliant.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) labeled with `bug`
- [ ] New feature (non-breaking change which adds functionality) labeled with `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code standards](/CONTRIBUTING.md) of this project.
- [ ] My change requires updating the documentation. I have updated the documentation accordingly.
