### PR TITLE
Add Docker Node Storage run modes for chart support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,4 +51,4 @@ HEALTHCHECK --interval=15s --timeout=3s --start-period=5s CMD curl --fail http:/
 
 WORKDIR /websight
 ENTRYPOINT [ "/websight/bin/launch.sh" ]
-CMD ["websight-cms-starter-tar"]
+CMD ["tar"]

--- a/README.md
+++ b/README.md
@@ -183,9 +183,24 @@ distribution/target/dependency/org.apache.sling.feature.launcher/bin/launcher \
   -f distribution/target/slingfeature-tmp/feature-websight-cms-starter-tar.json
 ```
 
-Your local environment should be ready after a few seconds. To view it, open http://localhost:8080/ in a Web browser and log in using the credentials `wsadmin`/`wsadmin`.
+Then open http://localhost:8080/ in a Web browser and log in using the credentials `wsadmin`/`wsadmin`.
 
 For more details please refer to our [Developers quick start guide](https://docs.websight.io/cms/developers/quick-start/).
+
+### Run modes
+
+Running the `starter` WebSight CMS project requires selecting [OAK Node Storage](https://jackrabbit.apache.org/oak/docs/nodestore/overview.html) mode. To choose the mode, run the distribution with one of the following configuration files:
+- `feature-websight-cms-starter-tar.json` - starts the project with the `TAR` Segment NodeStore mode (uses the local file system, by default `./launcher` directory)
+- `feature-websight-cms-starter-mongo.json` - starts the project with the `MongoDB` Document NodeStore mode (requires MongoDB instance)
+    
+To run the `stater` project with MongoDB run:
+```bash
+docker run -d -p 27017:27017 --env MONGO_INITDB_ROOT_USERNAME=mongoadmin \
+  --env MONGO_INITDB_ROOT_PASSWORD=mongoadmin mongo
+  
+MONGODB_HOST=localhost && MONGODB_PORT=27017 && distribution/target/dependency/org.apache.sling.feature.launcher/bin/launcher \
+  -f distribution/target/slingfeature-tmp/feature-websight-cms-starter-mongo.json
+```
 
 ## Project structure
 
@@ -193,7 +208,7 @@ For more details please refer to our [Developers quick start guide](https://docs
     - `backend` - contains application elements (components, templates, etc.) and Java code
     - `frontend` - contains frontend elements for low code template (scss, ts, fonts etc.)
 - `content` - contains sample content created with use of application
-- `distribution` - builds a distribution of the project - instance feature model and docker images for runtime components
+- `distribution` - builds a distribution (Sling OSGi Feature) of the project
 - `tests` - responsible for the automatic distribution validation
     - `content` - contains content used for end-to-end tests
     - `end-to-end` - end-to-end tests validating distribution
@@ -201,6 +216,21 @@ For more details please refer to our [Developers quick start guide](https://docs
 ## Executing end-to-end tests
 
 Check the tests [README](./tests/README.md) for more details.
+
+## Docker
+You can run a containerized version of the project by building the Docker image with the following command:
+```bash
+docker build -t ds/websight-cms-starter .
+```
+And running it with:
+```bash
+docker run -p 8080:8080 --name websight-cms-ce --rm \
+  --mount source=tar-repo,target=/websight/repository ds/websight-cms-starter
+```
+
+By default, the `tar` mode is used.
+
+You can find an example WebSight CMS Starter with MongoDB setup in the [CMS Helm Chart](https://github.com/websight-io/charts).
 
 ## Contributing
 

--- a/distribution/src/main/container/bin/launch.sh
+++ b/distribution/src/main/container/bin/launch.sh
@@ -14,11 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-feature_name="${1}"
-feature=$(find artifacts -name "*${feature_name}*.slingosgifeature")
+oak_store_mode="${1}"
+feature=$(find artifacts -name "*websight-cms-starter-${oak_store_mode}*.slingosgifeature")
 
 if [[ ! -f "${feature}" ]]; then
-    echo "[ERROR] Did not find any feature file matching name ${feature_name}. Aborting"
+    echo "[ERROR] Did not find any feature file matching name 'websight-cms-starter-${oak_store_mode}'. Aborting"
     exit 1
 fi
 


### PR DESCRIPTION
## Description
A unified way of running TAR or MongoDB is needed for Helm chart support.

## Motivation and Context
This way of running Docker container with TAR or MongoDB oak node storage backend should be consistent and easy to switch between.

## Upgrade notes (if appropriate)
Running `Docker` container requires passing the mode: `tar` or `mongo` (`tar` is default).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) labeled with `bug`
- [ ] New feature (non-breaking change which adds functionality) labeled with `enhancement`
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code standards](/CONTRIBUTING.md) of this project.
- [x] My change requires updating the documentation. I have updated the documentation accordingly.
