### PR TITLE
WOS-590 Visual tests compare luna pages only for one space

### DIFF
--- a/tests/end-to-end/backstop.js
+++ b/tests/end-to-end/backstop.js
@@ -54,7 +54,7 @@ const scenarios = [
 
   const scenarioConfig = {
     removeSelectors,
-    label: scenario.page,
+    label: `${scenario.space}_${scenario.page}`,
     cookiePath: 'backstop_data/engine_scripts/cookies.json',
     url: getPublishedPageUrl(scenario),
     delay: 500,


### PR DESCRIPTION
Visual tests should validate pages in all the spaces. Previous configuration was working in a way that next space override previous one.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) labeled with `bug`
- [ ] New feature (non-breaking change which adds functionality) labeled with `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code standards](/CONTRIBUTING.md) of this project.
- [ ] My change requires updating the documentation. I have updated the documentation accordingly.
