### PR TITLE
WOS-599 Action running tests with WebSight CMS development version fix

### DIFF
--- a/.github/workflows/ci-test-starter-vs-cms-development.yml
+++ b/.github/workflows/ci-test-starter-vs-cms-development.yml
@@ -70,7 +70,14 @@ jobs:
       - name: Update dependencies to the latest snapshot version
         env:
           AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
-        run: ./mvnw versions:update-properties
+        run: |
+          export CMS_VERSION=`./mvnw versions:update-properties | grep 'Updated ${websight.cms.version}.*SNAPSHOT' | sed 's/.*Updated ${websight.cms.version} from.*to //'`
+          if [ -z '$CMS_VERSION' ]; then
+            echo 'WebSight CMS version not updated'
+            exit 1
+          else
+            echo 'WebSight CMS version updated to $CMS_VERSION'
+          fi    
 
       - name: Build and test
         env:

--- a/.github/workflows/ci-test-starter-vs-cms-development.yml
+++ b/.github/workflows/ci-test-starter-vs-cms-development.yml
@@ -72,11 +72,11 @@ jobs:
           AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
         run: |
           export CMS_VERSION=`./mvnw versions:update-properties | grep 'Updated ${websight.cms.version}.*SNAPSHOT' | sed 's/.*Updated ${websight.cms.version} from.*to //'`
-          if [ -z '$CMS_VERSION' ]; then
+          if [ -z "$CMS_VERSION" ]; then
             echo 'WebSight CMS version not updated'
             exit 1
           else
-            echo 'WebSight CMS version updated to $CMS_VERSION'
+            echo "WebSight CMS version updated to $CMS_VERSION"
           fi    
 
       - name: Build and test

--- a/.github/workflows/ci-test-starter-vs-cms-development.yml
+++ b/.github/workflows/ci-test-starter-vs-cms-development.yml
@@ -22,7 +22,6 @@ on:
 env:
   AWS_REGION: "eu-central-1"
   APP_FRONTEND_MODULE: application/frontend
-  E2E_TESTS_MODULE: tests/end-to-end
 
 permissions:
   id-token: write
@@ -49,8 +48,6 @@ jobs:
           path: |
             ${{ env.APP_FRONTEND_MODULE }}/node
             ${{ env.APP_FRONTEND_MODULE }}/node_modules
-            ${{ env.E2E_TESTS_MODULE }}/node
-            ${{ env.E2E_TESTS_MODULE }}/node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
 
       - name: Configure AWS Credentials

--- a/.github/workflows/ci-verify-build.yml
+++ b/.github/workflows/ci-verify-build.yml
@@ -23,7 +23,6 @@ on:
 
 env:
   APP_FRONTEND_MODULE: application/frontend
-  E2E_TESTS_MODULE: tests/end-to-end
 
 jobs:
   verify-cms-docker-image:
@@ -74,8 +73,6 @@ jobs:
           path: |
             ${{ env.APP_FRONTEND_MODULE }}/node
             ${{ env.APP_FRONTEND_MODULE }}/node_modules
-            ${{ env.E2E_TESTS_MODULE }}/node
-            ${{ env.E2E_TESTS_MODULE }}/node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
 
       - name: Verify Starter CMS Feature model with integration and E2E tests
@@ -105,8 +102,6 @@ jobs:
           path: |
             ${{ env.APP_FRONTEND_MODULE }}/node
             ${{ env.APP_FRONTEND_MODULE }}/node_modules
-            ${{ env.E2E_TESTS_MODULE }}/node
-            ${{ env.E2E_TESTS_MODULE }}/node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
 
       - name: Visual tests - create reference snapshots
@@ -141,8 +136,6 @@ jobs:
           path: |
             ${{ env.APP_FRONTEND_MODULE }}/node
             ${{ env.APP_FRONTEND_MODULE }}/node_modules
-            ${{ env.E2E_TESTS_MODULE }}/node
-            ${{ env.E2E_TESTS_MODULE }}/node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
 
       - name: Download reference screenshots

--- a/.github/workflows/ci-verify-dev-journey.yml
+++ b/.github/workflows/ci-verify-dev-journey.yml
@@ -23,7 +23,6 @@ permissions:
 
 env:
   APP_FRONTEND_MODULE: application/frontend
-  E2E_TESTS_MODULE: tests/end-to-end
 
 jobs:
   verify-dev-journey:
@@ -47,8 +46,6 @@ jobs:
           path: |
             ${{ env.APP_FRONTEND_MODULE }}/node
             ${{ env.APP_FRONTEND_MODULE }}/node_modules
-            ${{ env.E2E_TESTS_MODULE }}/node
-            ${{ env.E2E_TESTS_MODULE }}/node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
 
       - name: Build and install Nodejs, NPM, and Cypress

--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,7 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <!-- required to update version by versions-maven-plugin -->
         <groupId>pl.ds.websight</groupId>
         <artifactId>websight-cms-ce-feature</artifactId>
         <version>${websight.cms.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <websight.admin.omitAdminPw>true</websight.admin.omitAdminPw>
 
     <!-- WebSight CMS Version -->
-    <!-- remember to update the verion in Dockerfile too! -->
+    <!-- remember to update the version in Dockerfile too! -->
     <websight.cms.version>1.23.0</websight.cms.version>
 
     <timestamp>${maven.build.timestamp}</timestamp>
@@ -143,6 +143,17 @@
       </plugins>
     </pluginManagement>
   </build>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>pl.ds.websight</groupId>
+        <artifactId>websight-cms-ce-feature</artifactId>
+        <version>${websight.cms.version}</version>
+        <scope>provided</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <repositories>
     <repository>


### PR DESCRIPTION
We have nightly builds that validate if the Starter project runs properly with the WebSight CMS development version, but changing the WebSight CMS version didn't work.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) labeled with `bug`
- [ ] New feature (non-breaking change which adds functionality) labeled with `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code standards](/CONTRIBUTING.md) of this project.
- [ ] My change requires updating the documentation. I have updated the documentation accordingly.
